### PR TITLE
Rename fold_smooth{,step} parameter

### DIFF
--- a/include/parafields/matrix.hh
+++ b/include/parafields/matrix.hh
@@ -558,11 +558,11 @@ private:
       if ((*traits).verbose && rank == 0)
         std::cout << "fold periodization" << std::endl;
 
-      if (sigmoid == "fold_smooth")
+      if (sigmoid == "smooth")
         computeMatrixEntriesWithFold<Covariance,
                                      GeometryMatrix,
                                      SmoothSigmoid>();
-      else if (sigmoid == "fold_smoothstep")
+      else if (sigmoid == "smoothstep")
         computeMatrixEntriesWithFold<Covariance,
                                      GeometryMatrix,
                                      SmoothstepSigmoid>();


### PR DESCRIPTION
It is not consistent with the other parameters and the documentation and error messages. I am assuming that this was a mistake.