### PR TITLE
Fix GSL code path for single precision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Configure using cmake
         working-directory: ${{ runner.workspace  }}/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_GSL=ON
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug
 
       - name: Build project
         working-directory: ${{ runner.workspace }}/build

--- a/include/parafields/gslfallback.hh
+++ b/include/parafields/gslfallback.hh
@@ -1,0 +1,24 @@
+#pragma once
+
+#if HAVE_GSL
+
+#include <gsl/gsl_integration.h>
+
+#include <stdexcept>
+
+int
+gsl_integration_qng(const gsl_function*,
+                    float,
+                    float,
+                    float,
+                    float,
+                    float*,
+                    float*,
+                    size_t*)
+{
+  throw std::runtime_error{
+    "GSL backend only available for double precision!"
+  };
+}
+
+#endif // HAVE_GSL

--- a/include/parafields/matrix.hh
+++ b/include/parafields/matrix.hh
@@ -8,6 +8,7 @@
 #include <fftw3.h>
 
 #include "parafields/covariance.hh"
+#include "parafields/gslfallback.hh"
 
 #include "parafields/backends/fftwwrapper.hh"
 
@@ -850,7 +851,7 @@ private:
       maxFactor * 0.5 * (*traits).embeddingFactor / std::sqrt(RF(dim));
     params[2] = recursions;
 
-    auto func = [](RF x, void* params) {
+    auto func = [](double x, void* params) {
       const double alpha = ((double*)params)[0];
       const double beta = ((double*)params)[1];
       const double gamma = ((double*)params)[2];
@@ -967,7 +968,7 @@ private:
     params[1] = std::min(maxFactor * maxBorder, minConstrained);
     params[2] = recursion;
 
-    auto func = [](RF x, void* params) {
+    auto func = [](double x, void* params) {
       const double alpha = ((double*)params)[0];
       const double beta = ((double*)params)[1];
       const double gamma = ((double*)params)[2];


### PR DESCRIPTION
Providing an error throwing fallback for the only signature that is not available.

THis fixes #11 