### PR TITLE
Refactoring: Forward covariance function objects

### DIFF
--- a/include/parafields/covariance.hh
+++ b/include/parafields/covariance.hh
@@ -297,13 +297,6 @@ class SphericalCovariance
 {
 public:
   /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  SphericalCovariance(const Dune::ParameterTree& config) {}
-
-  /**
    * @brief Evaluate the covariance function
    *
    * @tparam RF      type of values and coordinates
@@ -358,13 +351,6 @@ public:
 class ExponentialCovariance
 {
 public:
-  /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  ExponentialCovariance(const Dune::ParameterTree& config) {}
-
   /**
    * @brief Evaluate the covariance function
    *
@@ -448,13 +434,6 @@ class GaussianCovariance
 {
 public:
   /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  GaussianCovariance(const Dune::ParameterTree& config) {}
-
-  /**
    * @brief Evaluate the covariance function
    *
    * @tparam RF      type of values and coordinates
@@ -486,13 +465,6 @@ public:
 class SeparableExponentialCovariance
 {
 public:
-  /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  SeparableExponentialCovariance(const Dune::ParameterTree& config) {}
-
   /**
    * @brief Evaluate the covariance function
    *
@@ -595,13 +567,6 @@ class Matern32Covariance
 {
 public:
   /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  Matern32Covariance(const Dune::ParameterTree& config) {}
-
-  /**
    * @brief Evaluate the covariance function
    *
    * @tparam RF      type of values and coordinates
@@ -636,13 +601,6 @@ class Matern52Covariance
 {
 public:
   /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  Matern52Covariance(const Dune::ParameterTree& config) {}
-
-  /**
    * @brief Evaluate the covariance function
    *
    * @tparam RF      type of values and coordinates
@@ -675,13 +633,6 @@ public:
 class DampedOscillationCovariance
 {
 public:
-  /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  DampedOscillationCovariance(const Dune::ParameterTree& config) {}
-
   /**
    * @brief Evaluate the covariance function
    *
@@ -716,13 +667,6 @@ public:
 class CauchyCovariance
 {
 public:
-  /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  CauchyCovariance(const Dune::ParameterTree& config) {}
-
   /**
    * @brief Evaluate the covariance function
    *
@@ -810,13 +754,6 @@ class CubicCovariance
 {
 public:
   /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  CubicCovariance(const Dune::ParameterTree& config) {}
-
-  /**
    * @brief Evaluate the covariance function
    *
    * @tparam RF      type of values and coordinates
@@ -862,13 +799,6 @@ public:
 class WhiteNoiseCovariance
 {
 public:
-  /**
-   * @brief Constructor
-   *
-   * @param config unused dummy argument
-   */
-  WhiteNoiseCovariance(const Dune::ParameterTree& config) {}
-
   /**
    * @brief Evaluate the covariance function
    *

--- a/include/parafields/randomfield.hh
+++ b/include/parafields/randomfield.hh
@@ -434,21 +434,24 @@ public:
    * @brief Explicit matrix setup for custom covariance classes
    *
    * This function can be called if a custom user-supplied covariance
-   * function should be used. The function is passed as a template
-   * parameter, and has to fulfill the interface of the built-in
-   * covariance functions. In the configuration, "custom-iso" or
+   * function should be used. The function is passed as a callable (e.g.
+   * a (std::)function, a functor etc). In the configuration, "custom-iso" or
    * "custom-aniso" has to be chosen as the desired covariance type.
    * The former assumes that the covariance function is symmetric in
    * each dimension, leading to significant memory savings, and will
    * not work if that is not the case.
    */
   template<typename Covariance>
-  void fillMatrix()
+  void fillMatrix(Covariance&& covariance)
   {
     if (useAnisoMatrix)
-      (*anisoMatrix).template fillTransformedMatrix<Covariance>();
+      (*anisoMatrix)
+        .template fillTransformedMatrix<Covariance>(
+          std::forward<Covariance>(covariance));
     else
-      (*isoMatrix).template fillTransformedMatrix<Covariance>();
+      (*isoMatrix)
+        .template fillTransformedMatrix<Covariance>(
+          std::forward<Covariance>(covariance));
   }
 
   /**


### PR DESCRIPTION
This allows custom covariance functions to be passed through Python bindings.