### PR TITLE
Allow passing an instantiated RNG to RandomField

### DIFF
--- a/include/parafields/fieldtraits.hh
+++ b/include/parafields/fieldtraits.hh
@@ -103,10 +103,13 @@ private:
   friend AnisoMatrix<ThisType>;
   friend typename IsoMatrix<ThisType>::MatrixBackendType;
   friend typename IsoMatrix<ThisType>::FieldBackendType;
-  friend typename IsoMatrix<ThisType>::RNGBackendType;
   friend typename AnisoMatrix<ThisType>::MatrixBackendType;
   friend typename AnisoMatrix<ThisType>::FieldBackendType;
-  friend typename AnisoMatrix<ThisType>::RNGBackendType;
+
+  friend CppRNGBackend<ThisType>;
+#if HAVE_GSL
+  friend GSLRNGBackend<ThisType>;
+#endif
 
   friend RandomField<GridTraits, IsoMatrix, AnisoMatrix>;
 

--- a/include/parafields/matrix.hh
+++ b/include/parafields/matrix.hh
@@ -330,7 +330,7 @@ public:
    * @param[out] stochasticPart resulting random field
    */
   template<typename RNG>
-  void generateField(RNG&& rngBackend, StochasticPartType& stochasticPart) const
+  void generateField(RNG& rngBackend, StochasticPartType& stochasticPart) const
   {
     if (!matrixBackend.valid())
       fillTransformedMatrix();

--- a/include/parafields/randomfield.hh
+++ b/include/parafields/randomfield.hh
@@ -504,7 +504,7 @@ public:
     seed += this->traits->rank; // different seed for each processor
     rngBackend.seed(seed);
 
-    generateWithRNG(rngBackend, seed, allowNonWorldComm);
+    generateWithRNG(rngBackend, allowNonWorldComm);
   }
 
   /**
@@ -515,14 +515,10 @@ public:
    * generation.
    *
    * @param rngBackend        The RNG providing a sample() method
-   * @param seed              seed value for random number generation (still
-   * used in trend)
    * @param allowNonWorldComm prevent inconsistent field generation by default
    */
   template<typename RNG>
-  void generateWithRNG(RNG&& rngBackend,
-                       unsigned int seed,
-                       bool allowNonWorldComm = false)
+  void generateWithRNG(RNG& rngBackend, bool allowNonWorldComm = false)
   {
     if (((*traits).comm != MPI_COMM_WORLD) && !allowNonWorldComm)
       throw std::runtime_error{
@@ -531,11 +527,10 @@ public:
       };
 
     if (useAnisoMatrix)
-      (*anisoMatrix)
-        .generateField(std::forward<RNG>(rngBackend), stochasticPart);
+      (*anisoMatrix).generateField(rngBackend, stochasticPart);
     else
-      (*isoMatrix).generateField(std::forward<RNG>(rngBackend), stochasticPart);
-    trendPart.generate(seed);
+      (*isoMatrix).generateField(rngBackend, stochasticPart);
+    trendPart.generate(rngBackend);
 
     invMatvecValid = false;
     invRootMatvecValid = false;


### PR DESCRIPTION
This is required to allow exposing the RNG to Python users.