### PR TITLE
Remove deprecated dune header

### DIFF
--- a/include/parafields/stochastic.hh
+++ b/include/parafields/stochastic.hh
@@ -2,7 +2,6 @@
 
 #include <fstream>
 
-#include <dune/common/power.hh>
 #if HAVE_DUNE_PDELAB
 #include <dune/pdelab/gridfunctionspace/gridfunctionspaceutilities.hh>
 #endif // HAVE_DUNE_PDELAB


### PR DESCRIPTION
`<dune/common/power.hh>` was [removed by dune-common](https://gitlab.dune-project.org/core/dune-common/-/merge_requests/1304#28d14a61a4c65fa6d15c761df80f25f873cdaa2b) in current master. I could not find any explicit usage of its contents so I removed it for this PR. If anything is wrong I hope that the GitHub actions catches it :)